### PR TITLE
Fixing vendor alias

### DIFF
--- a/app/config/common.php
+++ b/app/config/common.php
@@ -13,7 +13,7 @@ return array(
 	'basePath' => realPath(__DIR__ . '/..'),
 	'preload' => array('log'),
 	'aliases' => array(
-		'vendor' => 'application.vendor'
+		'vendor' => 'application.lib.vendor'
 	),
 	'import' => array(
 		'application.controllers.*',


### PR DESCRIPTION
It seems that `lib` part is missing in `vendor` alias
