### PR TITLE
Invalid alias for vendor folder.

### DIFF
--- a/app/config/common.php
+++ b/app/config/common.php
@@ -13,7 +13,7 @@ return array(
 	'basePath' => realPath(__DIR__ . '/..'),
 	'preload' => array('log'),
 	'aliases' => array(
-		'vendor' => 'application.vendor'
+		'vendor' => 'application.lib.vendor'
 	),
 	'import' => array(
 		'application.controllers.*',


### PR DESCRIPTION
This mistake did not let to use some vendor classes. Particularly TbHtml.
